### PR TITLE
Tweak docs and improve restartibility

### DIFF
--- a/powerpc/README.md
+++ b/powerpc/README.md
@@ -70,9 +70,11 @@ Notes:
 
 
 ### Build & install BlazingSQL on Summit
-The following instructions are for building on Summit. They are similar to the instructions above:
+The following instructions are for building on Summit. They are similar to the instructions above.
 
-Use lmod to load up all the dependencies:
+**The order of the following steps is important, because the python module needs to be loaded first before creating the virtual environment.**
+
+1. Use lmod to load up all the dependencies.
 ```shell
 module load gcc/7.4.0
 module load python/3.7.0
@@ -90,7 +92,7 @@ module load gdrcopy
 module list
 ```
 
-Export the environment variables for your Virtual Environment and Build folder and make sure the folders exist:
+2. Export the environment variables for your Virtual Environment and Build folder and make sure the folders exist:
 ```shell
 export VIRTUAL_ENV=PATH_TO_YOUR_ENV_PREFIX
 mkdir $VIRTUAL_ENV
@@ -98,13 +100,13 @@ export BLAZINGSQL_POWERPC_TMP_BUILD_DIR=PATH_TO_A_BUILD_FOLDER
 mkdir $BLAZINGSQL_POWERPC_TMP_BUILD_DIR
 ```
 
-Create your virtual environment and activate it:
+3. Create your virtual environment and activate it:
 ```shell
 python -m venv $VIRTUAL_ENV
 source $VIRTUAL_ENV/bin/activate
 ```
 
-Make sure you are in the `blazingsql` folder and run the build script and pass your environment folder as argument:
+4. Make sure you are in the `blazingsql` folder and run the build script and pass your environment folder as argument:
 ```shell
 cd blazingsql
 source powerpc/build.sh $VIRTUAL_ENV  | tee out.txt

--- a/powerpc/build.sh
+++ b/powerpc/build.sh
@@ -56,6 +56,8 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/
 
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$tmp_dir/lib
 
+export CMAKE_PREFIX_PATH=$VIRTUAL_ENV:$CMAKE_PREFIX_PATH
+
 echo "### Vars ###"
 echo "CC="$CC
 echo "CXX="$CXX
@@ -344,63 +346,62 @@ if [ "$machine_processor_architecture" = "ppc64le" ] || [ "$machine_processor_ar
     git clone --depth 1 https://github.com/numba/llvmlite.git --branch "release$llvmlite_version_from_pip" --single-branch
     cd llvmlite/
     pip install .
-
-    echo "### BEGIN Pip dependencies ###"
-    # pip install -r requirements.txt
-    echo "### pip installing numba ###"
-    pip install numba==0.50.1
-    echo "### pip installing scipy ###"
-    pip install scipy==1.5.2
-    echo "### pip installing scikit-learn ###"
-    pip install scikit-learn==0.23.1
-    echo "### pip installing flake8 ###"
-    pip install flake8==3.8.3
-    echo "### pip installing ipython ###"
-    pip install ipython==7.17.0
-    echo "### pip installing pytest-timeout ###"
-    pip install pytest-timeout==1.4.2
-    echo "### pip installing sphinx-rtd-theme ###"
-    pip install sphinx-rtd-theme==0.5.0
-    echo "### pip installing cysignals ###"
-    pip install cysignals==1.10.2
-    echo "### pip installing numpydoc ###"
-    pip install numpydoc==1.1.0
-    echo "### pip installing pynvml ###"
-    pip install pynvml==8.0.4
-    echo "### pip installing networkx ###"
-    pip install networkx==2.4
-    echo "### pip installing jupyterlab ###"
-    pip install jupyterlab==2.2.4
-    echo "### pip installing notebook ###"
-    pip install notebook==6.1.3
-    echo "### pip installing joblib ###"
-    pip install joblib==0.16.0
-    echo "### pip installing fastrlock ###"
-    pip install fastrlock==0.5
-    echo "### pip installing pytest-timeout ###"
-    pip install pytest-timeout==1.4.2
-    echo "### pip installing hypothesis ###"
-    pip install hypothesis==5.26.0
-    echo "### pip installing python-louvain ###"
-    pip install python-louvain==0.14
-    echo "### pip installing jupyter-server-proxy ###"
-    pip install jupyter-server-proxy==1.5.0
-    echo "### pip installing statsmodels ###"
-    pip install statsmodels==0.11.1
-    echo "### pip installing pyhive ###"
-    pip install pyhive==0.6.2
-    echo "### pip installing thrift ###"
-    pip install thrift==0.13.0
-    echo "### pip installing jpype1 ###"
-    pip install jpype1==1.0.2
-    echo "### pip installing netifaces ###"
-    pip install netifaces==0.10.9
-    echo "### END Pip dependencies ###"
-    echo "---->>> finished llvmlite"
  fi
 fi
 echo "END llvmlite"
 
+echo "### BEGIN Pip dependencies ###"
+# pip install -r requirements.txt
+echo "### pip installing numba ###"
+pip install numba==0.50.1
+echo "### pip installing scipy ###"
+LDFLAGS="-shared" pip install scipy==1.5.2
+echo "### pip installing scikit-learn ###"
+LDFLAGS="-shared" pip install scikit-learn==0.23.1
+echo "### pip installing flake8 ###"
+pip install flake8==3.8.3
+echo "### pip installing ipython ###"
+pip install ipython==7.17.0
+echo "### pip installing pytest-timeout ###"
+pip install pytest-timeout==1.4.2
+echo "### pip installing sphinx-rtd-theme ###"
+pip install sphinx-rtd-theme==0.5.0
+echo "### pip installing cysignals ###"
+pip install cysignals==1.10.2
+echo "### pip installing numpydoc ###"
+pip install numpydoc==1.1.0
+echo "### pip installing pynvml ###"
+pip install pynvml==8.0.4
+echo "### pip installing networkx ###"
+pip install networkx==2.4
+echo "### pip installing jupyterlab ###"
+pip install jupyterlab==2.2.4
+echo "### pip installing notebook ###"
+pip install notebook==6.1.3
+echo "### pip installing joblib ###"
+pip install joblib==0.16.0
+echo "### pip installing fastrlock ###"
+pip install fastrlock==0.5
+echo "### pip installing pytest-timeout ###"
+pip install pytest-timeout==1.4.2
+echo "### pip installing hypothesis ###"
+pip install hypothesis==5.26.0
+echo "### pip installing python-louvain ###"
+pip install python-louvain==0.14
+echo "### pip installing jupyter-server-proxy ###"
+pip install jupyter-server-proxy==1.5.0
+echo "### pip installing statsmodels ###"
+pip install statsmodels==0.11.1
+echo "### pip installing pyhive ###"
+pip install pyhive==0.6.2
+echo "### pip installing thrift ###"
+pip install thrift==0.13.0
+echo "### pip installing jpype1 ###"
+pip install jpype1==1.0.2
+echo "### pip installing netifaces ###"
+pip install netifaces==0.10.9
+echo "### END Pip dependencies ###"
+echo "---->>> finished llvmlite"
 
 # END numba llvmlite
 


### PR DESCRIPTION
Improve the ability to restart the build script after failure.

Pip always skips upgrades if a package with the same version already exists in the environment, that means, the pip install ... commands can (and should) be moved to the main scope.

Also fixes a crash with scipy/scikit-learn installation.

Warn about the right order of steps (first modules, then python env) in the documentation, as I've encountered issues when I first activated the environment with a previously loaded version of the python 3.7 module. 